### PR TITLE
Create wheel during cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
 option(LOCAL_INSTALL "Install locally" ON)
+option(BUILD_WHEEL "building wheel file while installing" OFF)
+
 
 IF(LOCAL_INSTALL)
 	SET(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/install) 

--- a/src/python/BuildWheel.cmake
+++ b/src/python/BuildWheel.cmake
@@ -1,0 +1,14 @@
+
+execute_process(
+	COMMAND pip wheel ${CMAKE_INSTALL_PREFIX}/python -w ${CMAKE_CURRENT_BINARY_DIR}/dist --no-deps
+	# commands
+)
+
+
+file(GLOB wheel_files ${CMAKE_CURRENT_BINARY_DIR}/dist/*.whl )
+file(COPY ${wheel_files} DESTINATION ${CMAKE_INSTALL_PREFIX}/dist )
+
+# file(
+#     COPY ${CMAKE_CURRENT_BINARY_DIR}/dist
+# 	DESTINATION ${CMAKE_INSTALL_PREFIX}
+# )

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,19 +1,5 @@
 
-
-add_custom_target(Build-wheel-${PROJECT_NAME} ALL DEPENDS ${PROJECT_NAME})
-
-add_custom_command(
-	TARGET Build-wheel-${PROJECT_NAME}
-	COMMAND pip wheel ${CMAKE_CURRENT_SOURCE_DIR}  -w ${CMAKE_CURRENT_BINARY_DIR}/dist --no-deps
-	# commands
-)
-
-install(
-	DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dist
-	DESTINATION ${CMAKE_INSTALL_PREFIX}
-)
-
-
+option(BUILD_WHEEL "building wheel file while installing" OFF)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/python
@@ -82,3 +68,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml ${PROJECT_SOURCE_DIR}/R
 )
 install(CODE "set(FFMPEG_INSTALL_DIR \"${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/libs\")")
 install(SCRIPT ../cpp/video_io/InstallFfmpeg.cmake) 
+
+
+if(BUILD_WHEEL)
+	install (SCRIPT BuildWheel.cmake)
+endif()
+
+ 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -70,6 +70,7 @@ install(SCRIPT ../cpp/video_io/InstallFfmpeg.cmake)
 
 
 if(BUILD_WHEEL)
+	message(STATUS "Building wheel after installation")
 	install (SCRIPT BuildWheel.cmake)
 endif()
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-option(BUILD_WHEEL "building wheel file while installing" OFF)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/python

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,5 +1,17 @@
 
 
+add_custom_target(Build-wheel-${PROJECT_NAME} ALL DEPENDS ${PROJECT_NAME})
+
+add_custom_command(
+	TARGET Build-wheel-${PROJECT_NAME}
+	COMMAND pip wheel ${CMAKE_CURRENT_SOURCE_DIR}  -w ${CMAKE_CURRENT_BINARY_DIR}/dist --no-deps
+	# commands
+)
+
+install(
+	DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dist
+	DESTINATION ${CMAKE_INSTALL_PREFIX}
+)
 
 
 


### PR DESCRIPTION
This PR proposes to create the wheel during the installation process. This way, the deployement is eased as it embeds all the C shared libraries.