### PR TITLE
to_h264 method doesn't work properly when saving partial movies

### DIFF
--- a/src/python/librir/video_io/IRMovie.py
+++ b/src/python/librir/video_io/IRMovie.py
@@ -575,6 +575,10 @@ class IRMovie(object):
         # retrieve attributes
         if attrs is None:
             attrs = self.attributes
+        if (frame_attributes is not None) and (len(frame_attributes) != count):
+            raise RuntimeError(
+                "Given frame attributes are not equal to the number of saved images"
+            )
 
         # adding custom attribute --> must be a dict[str]=str
         # attrs.update(self.additional_attributes)
@@ -606,10 +610,10 @@ class IRMovie(object):
                 img = self.load_pos(i, 0)
 
                 _frame_attributes = (
-                        self.frame_attributes
-                        if frame_attributes is None
-                        else frame_attributes[saved]
-                    )
+                    self.frame_attributes
+                    if frame_attributes is None
+                    else frame_attributes[saved]
+                )
 
                 s.add_image(img, times[i] * 1e9, attributes=_frame_attributes)
 

--- a/src/python/librir/video_io/IRMovie.py
+++ b/src/python/librir/video_io/IRMovie.py
@@ -565,6 +565,8 @@ class IRMovie(object):
             count = self.images
         if start_img + count > self.images:
             count = self.images - start_img
+        if count == 0:
+            raise RuntimeError("No images in selected range to save")
 
         logger.info(
             "Start saving in {} from {} to {}".format(

--- a/src/python/librir/video_io/IRMovie.py
+++ b/src/python/librir/video_io/IRMovie.py
@@ -606,10 +606,10 @@ class IRMovie(object):
                 img = self.load_pos(i, 0)
 
                 _frame_attributes = (
-                    self.frame_attributes
-                    if frame_attributes is None
-                    else frame_attributes[i]
-                )
+                        self.frame_attributes
+                        if frame_attributes is None
+                        else frame_attributes[saved]
+                    )
 
                 s.add_image(img, times[i] * 1e9, attributes=_frame_attributes)
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -125,7 +125,9 @@ VALID_MASKS = [generate_constant_mask_array(*shape) for shape in VALID_3D_SHAPES
 #     return [IRMovie.from_numpy_array(arr) for arr in VALID_UNIFORM_NUMPY_ARRAYS]
 
 
-@pytest.fixture(scope="session", params=VALID_SHAPES)
+@pytest.fixture(
+    scope="session", params=VALID_SHAPES, ids=[str(s) for s in VALID_SHAPES]
+)
 def array(request):
     shape = request.param
     arr = generate_mock_movie_data_uniform(*shape)
@@ -133,19 +135,25 @@ def array(request):
     yield arr
 
 
-@pytest.fixture(scope="session", params=VALID_3D_SHAPES)
+@pytest.fixture(
+    scope="session", params=VALID_3D_SHAPES, ids=[str(s) for s in VALID_3D_SHAPES]
+)
 def valid_3d_array(request):
     shape = request.param
     yield generate_mock_movie_data_uniform(*shape)
 
 
-@pytest.fixture(scope="session", params=INVALID_SHAPES)
+@pytest.fixture(
+    scope="session", params=INVALID_SHAPES, ids=[str(s) for s in INVALID_SHAPES]
+)
 def bad_array(request):
     shape = request.param
     yield generate_mock_movie_data_uniform(*shape)
 
 
-@pytest.fixture(scope="session", params=VALID_2D_SHAPES)
+@pytest.fixture(
+    scope="session", params=VALID_2D_SHAPES, ids=[str(s) for s in VALID_2D_SHAPES]
+)
 def valid_2D_array(request):
     shape = request.param
     arr = generate_mock_movie_data_uniform(*shape)

--- a/tests/python/test_IRMovie.py
+++ b/tests/python/test_IRMovie.py
@@ -175,3 +175,11 @@ def test_flip_camera_calibration_when_no_calibration(movie: IRMovie):
         movie.flip_calibration(False, True)
     with pytest.raises(RuntimeError):
         movie.flip_calibration(True, True)
+
+
+def test_save_subset_of_movie_to_h264(movie: IRMovie):
+    dest_filename = f"{movie.filename}_subset.h264"
+
+    movie.to_h264(
+        dest_filename,
+    )

--- a/tests/python/test_IRMovie.py
+++ b/tests/python/test_IRMovie.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import random
+from typing import Dict
 from librir.video_io.utils import is_ir_file_corrupted, split_rush
 
 import numpy as np
@@ -179,7 +180,7 @@ def test_flip_camera_calibration_when_no_calibration(movie: IRMovie):
 
 
 @pytest.mark.parametrize("attrs", ({}, {"additional": 123}), ids=("none", "additional"))
-def test_save_subset_of_movie_to_h264(movie: IRMovie, attrs: dict[str, int]):
+def test_save_subset_of_movie_to_h264(movie: IRMovie, attrs: Dict[str, int]):
     dest_filename = Path(f"{movie.filename}_subset.h264")
     count = 1 if movie.images == 1 else movie.images // 2
     frame_attributes = [{"additional_frame_attribute": i} for i in range(movie.images)]

--- a/tests/python/test_IRMovie.py
+++ b/tests/python/test_IRMovie.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import random
 from librir.video_io.utils import is_ir_file_corrupted, split_rush
 
@@ -177,9 +178,61 @@ def test_flip_camera_calibration_when_no_calibration(movie: IRMovie):
         movie.flip_calibration(True, True)
 
 
-def test_save_subset_of_movie_to_h264(movie: IRMovie):
-    dest_filename = f"{movie.filename}_subset.h264"
+@pytest.mark.parametrize("attrs", ({}, {"additional": 123}), ids=("none", "additional"))
+def test_save_subset_of_movie_to_h264(movie: IRMovie, attrs: dict[str, int]):
+    dest_filename = Path(f"{movie.filename}_subset.h264")
+    count = 1 if movie.images == 1 else movie.images // 2
+    frame_attributes = [{"additional_frame_attribute": i} for i in range(movie.images)]
+
+    with pytest.raises(RuntimeError):
+        movie.to_h264(
+            dest_filename,
+            start_img=0,
+            count=movie.images // 2,
+            attrs=attrs,
+            frame_attributes=frame_attributes,
+        )
+    with pytest.raises(RuntimeError):
+        movie.to_h264(
+            dest_filename,
+            start_img=movie.images // 2,
+            count=movie.images // 2,
+            attrs=attrs,
+            frame_attributes=frame_attributes,
+        )
+    with pytest.raises(RuntimeError):
+        movie.to_h264(
+            dest_filename,
+            start_img=movie.images // 2,
+            count=0,
+            attrs=attrs,
+            frame_attributes=frame_attributes,
+        )
+    with pytest.raises(RuntimeError):
+        movie.to_h264(
+            dest_filename,
+            start_img=movie.images // 2,
+            count=0,
+            attrs=attrs,
+            frame_attributes=None,
+        )
+    # assert not dest_filename.exists()
 
     movie.to_h264(
         dest_filename,
+        start_img=0,
+        count=count,
+        attrs=attrs,
+        frame_attributes=[{"additional_frame_attribute": i} for i in range(count)],
     )
+    # assert dest_filename.exists()
+    expected_attrs = {k: str(v).encode() for k, v in attrs.items()}
+    expected_attrs["GOP"] = movie.attributes["GOP"]
+    # expected_attrs.update({k: str(v).encode() for k, v in attrs.items()})
+
+    with IRMovie.from_filename(dest_filename) as subset_movie:
+        # subset_movie.load_pos(0)
+        assert subset_movie.attributes == expected_attrs
+        assert len(subset_movie.frames_attributes) == subset_movie.images
+
+    # dest_filename.unlink()


### PR DESCRIPTION
When partially saving movies, the case where you use custom frame_attributes is not properly handled.
This PR fix theproblem and add some tests about it.