### PR TITLE
build: :wrench: add RIR_CONFIG_DIR in tools.

### DIFF
--- a/src/cpp/tools/CMakeLists.txt
+++ b/src/cpp/tools/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(tools PRIVATE $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>)
 target_include_directories(tools
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${RIR_CONFIG_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 


### PR DESCRIPTION
Adding it to include_directories allows to propagate it when reusing any of the librir modules because tools is the first in the chain.